### PR TITLE
fix compiling errors and forwarding issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@
 VERSION=1.1.0
 
 CC=gcc
-CFLAGS= -Wall -g -O3 
+CFLAGS= -Os -I./ 
 LDFLAGS=
-SOURCES=main.c icmp6.c util.c ip6.c config.c expintf.c exparser.c
+SOURCES=main.c icmp6.c util.c ip6.c config.c expintf.c exparser.c global.c
 OBJECTS=$(SOURCES:.c=.o)
 HEADERS=includes.h npd6.h
 EXECUTABLE=npd6

--- a/global.c
+++ b/global.c
@@ -1,0 +1,47 @@
+#include <npd6.h>
+
+//*****************************************************************************
+// Globals
+//
+char            *pname;
+char            *paramName;
+int             sockpkt;
+int             debug;
+int             daemonize;
+FILE            *logFileFD;
+int             logging;
+char            configfile[FILENAME_MAX];
+FILE            *configFileFD;
+int             initialIFFlags;
+
+unsigned int    interfaceCount;         // Total number of interface/prefix combos
+// We dynaimcally size this at run-time
+struct  npd6Interface *interfaces;
+
+// Key behaviour
+int             naLinkOptFlag;      // From config file NPD6OPTFLAG
+int             nsIgnoreLocal;      // From config file NPD6LOCALIG
+int             naRouter;           // From config file NPD6ROUTERNA
+int             maxHops;            // From config file NPD6MAXHOPS
+int             collectTargets;     // From config file NPD6TARGETS
+
+// Target tree data structures etc
+void            *tRoot;
+int             tCompare(const void *, const void *);
+void            tDump(const void *, const VISIT , const int);
+int             tEntries;
+
+// Black/whitelisting data
+void            *lRoot;
+int             listType;
+#define         NOLIST      0
+#define         BLACKLIST   1
+#define         WHITELIST   2
+int             listLog;            // From config file NPD6LISTLOG
+
+// Logging - various
+int             ralog;              // From config file NPD6RALOG
+
+// Error handling
+int		        pollErrorLimit;     // From config file
+

--- a/icmp6.c
+++ b/icmp6.c
@@ -404,8 +404,9 @@ sinfulexit:
  */
 int init_sockets(void)
 {
-    int errcount = 0;
+    int errcount = 0, err;
     int loop, sock, sockicmp;
+    struct ifreq ifr;
 
     /* Raw socket for receiving NSs */
     for (loop=0; loop < interfaceCount; loop++)
@@ -428,6 +429,16 @@ int init_sockets(void)
             flog(LOG_ERR, "open_icmpv6_socket: failed.");
             errcount++;
         }
+	
+        memset(&ifr, 0, sizeof(ifr));
+        strcpy(ifr.ifr_name, interfaces[loop].nameStr);
+	err = setsockopt(sockicmp, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr));
+        if ( err < 0) 
+	{
+	   flog(LOG_ERR, "bindtodevice: failed.");
+	   errcount ++;
+	}
+
         flog(LOG_DEBUG, "open_icmpv6_socket: OK.");
         interfaces[loop].icmpSock = sockicmp;
     }

--- a/includes.h
+++ b/includes.h
@@ -53,7 +53,6 @@
 #include <netinet/ip6.h>
 #include <netinet/icmp6.h>
 #include <arpa/inet.h>
-#include <sys/sysctl.h>
 #include <net/if.h>
 #include <getopt.h>
 #include <ifaddrs.h>

--- a/npd6.h
+++ b/npd6.h
@@ -65,16 +65,16 @@
 //*****************************************************************************
 // Globals
 //
-char            *pname;
-char            *paramName;
-int             sockpkt;
-int             debug;
-int             daemonize;
-FILE            *logFileFD;
-int             logging;
-char            configfile[FILENAME_MAX];
-FILE            *configFileFD;
-int             initialIFFlags;
+extern char            *pname;
+extern char            *paramName;
+extern int             sockpkt;
+extern int             debug;
+extern int             daemonize;
+extern FILE            *logFileFD;
+extern int             logging;
+extern char            configfile[FILENAME_MAX];
+extern FILE            *configFileFD;
+extern int             initialIFFlags;
 
 // Record of interfaces, prefix, indices, etc.
 struct npd6Interface {
@@ -88,36 +88,36 @@ struct npd6Interface {
     int             pktSock;
     int             icmpSock;
 };
-unsigned int    interfaceCount;         // Total number of interface/prefix combos
+extern unsigned int    interfaceCount;         // Total number of interface/prefix combos
 // We dynaimcally size this at run-time
-struct  npd6Interface *interfaces;
+extern struct  npd6Interface *interfaces;
 
 // Key behaviour
-int             naLinkOptFlag;      // From config file NPD6OPTFLAG
-int             nsIgnoreLocal;      // From config file NPD6LOCALIG
-int             naRouter;           // From config file NPD6ROUTERNA
-int             maxHops;            // From config file NPD6MAXHOPS
-int             collectTargets;     // From config file NPD6TARGETS
+extern int             naLinkOptFlag;      // From config file NPD6OPTFLAG
+extern int             nsIgnoreLocal;      // From config file NPD6LOCALIG
+extern int             naRouter;           // From config file NPD6ROUTERNA
+extern int             maxHops;            // From config file NPD6MAXHOPS
+extern int             collectTargets;     // From config file NPD6TARGETS
 
 // Target tree data structures etc
-void            *tRoot;
-int             tCompare(const void *, const void *);
-void            tDump(const void *, const VISIT , const int);
-int             tEntries;
+extern void            *tRoot;
+extern int             tCompare(const void *, const void *);
+extern void            tDump(const void *, const VISIT , const int);
+extern int             tEntries;
 
 // Black/whitelisting data
-void            *lRoot;
-int             listType;
+extern void            *lRoot;
+extern int             listType;
 #define         NOLIST      0
 #define         BLACKLIST   1
 #define         WHITELIST   2
-int             listLog;            // From config file NPD6LISTLOG
+extern int             listLog;            // From config file NPD6LISTLOG
 
 // Logging - various
-int             ralog;              // From config file NPD6RALOG
+extern int             ralog;              // From config file NPD6RALOG
 
 // Error handling
-int		        pollErrorLimit;     // From config file
+extern int		        pollErrorLimit;     // From config file
 
 //*****************************************************************************
 // Prototypes


### PR DESCRIPTION
1. move global variables from npd6.h to a new .c file and only declare them in original header file
2. fix the issue that npd6 wont work well when multiple interfaces have same prefix